### PR TITLE
ledger: fix consensus version flushes incorrectly (#2096)

### DIFF
--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -684,6 +684,11 @@ func (au *accountUpdates) committedUpTo(committedRound basics.Round) (retRound b
 
 	offset = uint64(newBase - au.dbRound)
 
+<<<<<<< HEAD
+=======
+	offset = au.consecutiveVersion(offset)
+
+>>>>>>> 0b885fe3... ledger: fix consensus version flushes incorrectly (#2096)
 	// check to see if this is a catchpoint round
 	isCatchpointRound = ((offset + uint64(lookback+au.dbRound)) > 0) && (au.catchpointInterval != 0) && (0 == (uint64((offset + uint64(lookback+au.dbRound))) % au.catchpointInterval))
 
@@ -716,6 +721,22 @@ func (au *accountUpdates) committedUpTo(committedRound basics.Round) (retRound b
 		au.accountsWriting.Add(1)
 	}
 	return
+}
+
+func (au *accountUpdates) consecutiveVersion(offset uint64) uint64 {
+	// check if this update chunk spans across multiple consensus versions. If so, break it so that each update would tackle only a single
+	// consensus version.
+	if au.versions[1] != au.versions[offset] {
+		// find the tip point.
+		tipPoint := sort.Search(int(offset), func(i int) bool {
+			// we're going to search here for version inequality, with the assumption that consensus versions won't repeat.
+			// that allow us to support [ver1, ver1, ..., ver2, ver2, ..., ver3, ver3] but not [ver1, ver1, ..., ver2, ver2, ..., ver1, ver3].
+			return au.versions[1] != au.versions[1+i]
+		})
+		// no need to handle the case of "no found", or tipPoint==int(offset), since we already know that it's there.
+		offset = uint64(tipPoint)
+	}
+	return offset
 }
 
 // newBlock is the accountUpdates implementation of the ledgerTracker interface. This is the "external" facing function
@@ -1881,6 +1902,15 @@ func (au *accountUpdates) commitRound(offset uint64, dbRound basics.Round, lookb
 
 	// adjust the offset according to what happened meanwhile..
 	offset -= uint64(au.dbRound - dbRound)
+
+	// if this iteration need to flush out zero rounds, just return right away.
+	// this usecase can happen when two subsequent calls to committedUpTo concludes that the same rounds range need to be
+	// flush, without the commitRound have a chance of committing these rounds.
+	if offset == 0 {
+		au.accountsMu.RUnlock()
+		return
+	}
+
 	dbRound = au.dbRound
 
 	newBase := basics.Round(offset) + dbRound
@@ -1895,7 +1925,18 @@ func (au *accountUpdates) commitRound(offset uint64, dbRound basics.Round, lookb
 	copy(deltas, au.deltas[:offset])
 	copy(creatableDeltas, au.creatableDeltas[:offset])
 	copy(roundTotals, au.roundTotals[:offset+1])
+<<<<<<< HEAD
 	copy(protos, au.protos[:offset+1])
+=======
+
+	// verify version correctness : all the entries in the au.versions[1:offset+1] should have the *same* version, and the committedUpTo should be enforcing that.
+	if au.versions[1] != au.versions[offset] {
+		au.accountsMu.RUnlock()
+		au.log.Errorf("attempted to commit series of rounds with non-uniform consensus versions")
+		return
+	}
+	consensusVersion := au.versions[1]
+>>>>>>> 0b885fe3... ledger: fix consensus version flushes incorrectly (#2096)
 
 	var committedRoundDigest crypto.Digest
 

--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -1545,3 +1545,381 @@ func TestReproducibleCatchpointLabels(t *testing.T) {
 		}
 	}
 }
+<<<<<<< HEAD
+=======
+
+// TestCachesInitialization test the functionality of the initializeCaches cache.
+func TestCachesInitialization(t *testing.T) {
+	protocolVersion := protocol.ConsensusCurrentVersion
+	proto := config.Consensus[protocolVersion]
+
+	initialRounds := uint64(1)
+
+	ml := makeMockLedgerForTracker(t, true, int(initialRounds), protocolVersion)
+	ml.log.SetLevel(logging.Warn)
+	defer ml.Close()
+
+	accountsCount := 5
+	accts := []map[basics.Address]basics.AccountData{randomAccounts(accountsCount, true)}
+	rewardsLevels := []uint64{0}
+
+	pooldata := basics.AccountData{}
+	pooldata.MicroAlgos.Raw = 1000 * 1000 * 1000 * 1000 * 1000 * 1000
+	pooldata.Status = basics.NotParticipating
+	accts[0][testPoolAddr] = pooldata
+
+	sinkdata := basics.AccountData{}
+	sinkdata.MicroAlgos.Raw = 1000 * 1000 * 1000 * 1000
+	sinkdata.Status = basics.NotParticipating
+	accts[0][testSinkAddr] = sinkdata
+
+	au := &accountUpdates{}
+	au.initialize(config.GetDefaultLocal(), ".", proto, accts[0])
+	err := au.loadFromDisk(ml)
+	require.NoError(t, err)
+
+	// cover initialRounds genesis blocks
+	rewardLevel := uint64(0)
+	for i := 1; i < int(initialRounds); i++ {
+		accts = append(accts, accts[0])
+		rewardsLevels = append(rewardsLevels, rewardLevel)
+	}
+
+	recoveredLedgerRound := basics.Round(initialRounds + initializeCachesRoundFlushInterval + proto.MaxBalLookback + 1)
+
+	for i := basics.Round(initialRounds); i <= recoveredLedgerRound; i++ {
+		rewardLevelDelta := crypto.RandUint64() % 5
+		rewardLevel += rewardLevelDelta
+		accountChanges := 2
+
+		updates, totals := randomDeltasBalanced(accountChanges, accts[i-1], rewardLevel)
+		prevTotals, err := au.Totals(basics.Round(i - 1))
+		require.NoError(t, err)
+
+		newPool := totals[testPoolAddr]
+		newPool.MicroAlgos.Raw -= prevTotals.RewardUnits() * rewardLevelDelta
+		updates.Upsert(testPoolAddr, newPool)
+		totals[testPoolAddr] = newPool
+
+		blk := bookkeeping.Block{
+			BlockHeader: bookkeeping.BlockHeader{
+				Round: basics.Round(i),
+			},
+		}
+		blk.RewardsLevel = rewardLevel
+		blk.CurrentProtocol = protocolVersion
+
+		delta := ledgercore.MakeStateDelta(&blk.BlockHeader, 0, updates.Len(), 0)
+		delta.Accts.MergeAccounts(updates)
+		ml.addMockBlock(blockEntry{block: blk}, delta)
+		au.newBlock(blk, delta)
+		au.committedUpTo(basics.Round(i))
+		au.waitAccountsWriting()
+		accts = append(accts, totals)
+		rewardsLevels = append(rewardsLevels, rewardLevel)
+	}
+	au.close()
+
+	// create another mocked ledger, but this time with a fresh new tracker database.
+	ml2 := makeMockLedgerForTracker(t, true, int(initialRounds), protocolVersion)
+	ml2.log.SetLevel(logging.Warn)
+	defer ml2.Close()
+
+	// and "fix" it to contain the blocks and deltas from before.
+	ml2.blocks = ml.blocks
+	ml2.deltas = ml.deltas
+
+	au = &accountUpdates{}
+	au.initialize(config.GetDefaultLocal(), ".", proto, accts[0])
+	err = au.loadFromDisk(ml2)
+	require.NoError(t, err)
+	defer au.close()
+
+	// make sure the deltas array end up containing only the most recent 320 rounds.
+	require.Equal(t, int(proto.MaxBalLookback), len(au.deltas))
+	require.Equal(t, recoveredLedgerRound-basics.Round(proto.MaxBalLookback), au.dbRound)
+}
+
+// TestSplittingConsensusVersionCommits tests the a sequence of commits that spans over multiple consensus versions works correctly.
+func TestSplittingConsensusVersionCommits(t *testing.T) {
+	initProtocolVersion := protocol.ConsensusV20
+	initialProtoParams := config.Consensus[initProtocolVersion]
+
+	initialRounds := uint64(1)
+
+	ml := makeMockLedgerForTracker(t, true, int(initialRounds), initProtocolVersion)
+	ml.log.SetLevel(logging.Warn)
+	defer ml.Close()
+
+	accountsCount := 5
+	accts := []map[basics.Address]basics.AccountData{randomAccounts(accountsCount, true)}
+	rewardsLevels := []uint64{0}
+
+	pooldata := basics.AccountData{}
+	pooldata.MicroAlgos.Raw = 1000 * 1000 * 1000 * 1000 * 1000 * 1000
+	pooldata.Status = basics.NotParticipating
+	accts[0][testPoolAddr] = pooldata
+
+	sinkdata := basics.AccountData{}
+	sinkdata.MicroAlgos.Raw = 1000 * 1000 * 1000 * 1000
+	sinkdata.Status = basics.NotParticipating
+	accts[0][testSinkAddr] = sinkdata
+
+	au := &accountUpdates{}
+	au.initialize(config.GetDefaultLocal(), ".", initialProtoParams, accts[0])
+	err := au.loadFromDisk(ml)
+	require.NoError(t, err)
+	defer au.close()
+
+	// cover initialRounds genesis blocks
+	rewardLevel := uint64(0)
+	for i := 1; i < int(initialRounds); i++ {
+		accts = append(accts, accts[0])
+		rewardsLevels = append(rewardsLevels, rewardLevel)
+	}
+
+	extraRounds := uint64(39)
+
+	// write the extraRounds rounds so that we will fill up the queue.
+	for i := basics.Round(initialRounds); i < basics.Round(initialRounds+extraRounds); i++ {
+		rewardLevelDelta := crypto.RandUint64() % 5
+		rewardLevel += rewardLevelDelta
+		accountChanges := 2
+
+		updates, totals := randomDeltasBalanced(accountChanges, accts[i-1], rewardLevel)
+		prevTotals, err := au.Totals(basics.Round(i - 1))
+		require.NoError(t, err)
+
+		newPool := totals[testPoolAddr]
+		newPool.MicroAlgos.Raw -= prevTotals.RewardUnits() * rewardLevelDelta
+		updates.Upsert(testPoolAddr, newPool)
+		totals[testPoolAddr] = newPool
+
+		blk := bookkeeping.Block{
+			BlockHeader: bookkeeping.BlockHeader{
+				Round: basics.Round(i),
+			},
+		}
+		blk.RewardsLevel = rewardLevel
+		blk.CurrentProtocol = initProtocolVersion
+
+		delta := ledgercore.MakeStateDelta(&blk.BlockHeader, 0, updates.Len(), 0)
+		delta.Accts.MergeAccounts(updates)
+		ml.addMockBlock(blockEntry{block: blk}, delta)
+		au.newBlock(blk, delta)
+		accts = append(accts, totals)
+		rewardsLevels = append(rewardsLevels, rewardLevel)
+	}
+
+	newVersionBlocksCount := uint64(47)
+	newVersion := protocol.ConsensusV21
+	// add 47 more rounds that contains blocks using a newer consensus version, and stuff it with MaxBalLookback
+	lastRoundToWrite := basics.Round(initialRounds + initialProtoParams.MaxBalLookback + extraRounds + newVersionBlocksCount)
+	for i := basics.Round(initialRounds + extraRounds); i < lastRoundToWrite; i++ {
+		rewardLevelDelta := crypto.RandUint64() % 5
+		rewardLevel += rewardLevelDelta
+		accountChanges := 2
+
+		updates, totals := randomDeltasBalanced(accountChanges, accts[i-1], rewardLevel)
+		prevTotals, err := au.Totals(basics.Round(i - 1))
+		require.NoError(t, err)
+
+		newPool := totals[testPoolAddr]
+		newPool.MicroAlgos.Raw -= prevTotals.RewardUnits() * rewardLevelDelta
+		updates.Upsert(testPoolAddr, newPool)
+		totals[testPoolAddr] = newPool
+
+		blk := bookkeeping.Block{
+			BlockHeader: bookkeeping.BlockHeader{
+				Round: basics.Round(i),
+			},
+		}
+		blk.RewardsLevel = rewardLevel
+		blk.CurrentProtocol = newVersion
+
+		delta := ledgercore.MakeStateDelta(&blk.BlockHeader, 0, updates.Len(), 0)
+		delta.Accts.MergeAccounts(updates)
+		ml.addMockBlock(blockEntry{block: blk}, delta)
+		au.newBlock(blk, delta)
+		accts = append(accts, totals)
+		rewardsLevels = append(rewardsLevels, rewardLevel)
+	}
+	// now, commit and verify that the committedUpTo method broken the range correctly.
+	au.committedUpTo(lastRoundToWrite)
+	au.waitAccountsWriting()
+	require.Equal(t, basics.Round(initialRounds+extraRounds)-1, au.dbRound)
+
+}
+
+// TestSplittingConsensusVersionCommitsBoundry tests the a sequence of commits that spans over multiple consensus versions works correctly, and
+// in particular, complements TestSplittingConsensusVersionCommits by testing the commit boundry.
+func TestSplittingConsensusVersionCommitsBoundry(t *testing.T) {
+	initProtocolVersion := protocol.ConsensusV20
+	initialProtoParams := config.Consensus[initProtocolVersion]
+
+	initialRounds := uint64(1)
+
+	ml := makeMockLedgerForTracker(t, true, int(initialRounds), initProtocolVersion)
+	ml.log.SetLevel(logging.Warn)
+	defer ml.Close()
+
+	accountsCount := 5
+	accts := []map[basics.Address]basics.AccountData{randomAccounts(accountsCount, true)}
+	rewardsLevels := []uint64{0}
+
+	pooldata := basics.AccountData{}
+	pooldata.MicroAlgos.Raw = 1000 * 1000 * 1000 * 1000 * 1000 * 1000
+	pooldata.Status = basics.NotParticipating
+	accts[0][testPoolAddr] = pooldata
+
+	sinkdata := basics.AccountData{}
+	sinkdata.MicroAlgos.Raw = 1000 * 1000 * 1000 * 1000
+	sinkdata.Status = basics.NotParticipating
+	accts[0][testSinkAddr] = sinkdata
+
+	au := &accountUpdates{}
+	au.initialize(config.GetDefaultLocal(), ".", initialProtoParams, accts[0])
+	err := au.loadFromDisk(ml)
+	require.NoError(t, err)
+	defer au.close()
+
+	// cover initialRounds genesis blocks
+	rewardLevel := uint64(0)
+	for i := 1; i < int(initialRounds); i++ {
+		accts = append(accts, accts[0])
+		rewardsLevels = append(rewardsLevels, rewardLevel)
+	}
+
+	extraRounds := uint64(39)
+
+	// write extraRounds rounds so that we will fill up the queue.
+	for i := basics.Round(initialRounds); i < basics.Round(initialRounds+extraRounds); i++ {
+		rewardLevelDelta := crypto.RandUint64() % 5
+		rewardLevel += rewardLevelDelta
+		accountChanges := 2
+
+		updates, totals := randomDeltasBalanced(accountChanges, accts[i-1], rewardLevel)
+		prevTotals, err := au.Totals(basics.Round(i - 1))
+		require.NoError(t, err)
+
+		newPool := totals[testPoolAddr]
+		newPool.MicroAlgos.Raw -= prevTotals.RewardUnits() * rewardLevelDelta
+		updates.Upsert(testPoolAddr, newPool)
+		totals[testPoolAddr] = newPool
+
+		blk := bookkeeping.Block{
+			BlockHeader: bookkeeping.BlockHeader{
+				Round: basics.Round(i),
+			},
+		}
+		blk.RewardsLevel = rewardLevel
+		blk.CurrentProtocol = initProtocolVersion
+
+		delta := ledgercore.MakeStateDelta(&blk.BlockHeader, 0, updates.Len(), 0)
+		delta.Accts.MergeAccounts(updates)
+		ml.addMockBlock(blockEntry{block: blk}, delta)
+		au.newBlock(blk, delta)
+		accts = append(accts, totals)
+		rewardsLevels = append(rewardsLevels, rewardLevel)
+	}
+
+	newVersion := protocol.ConsensusV21
+	// add MaxBalLookback-extraRounds more rounds that contains blocks using a newer consensus version.
+	endOfFirstNewProtocolSegment := basics.Round(initialRounds + extraRounds + initialProtoParams.MaxBalLookback)
+	for i := basics.Round(initialRounds + extraRounds); i <= endOfFirstNewProtocolSegment; i++ {
+		rewardLevelDelta := crypto.RandUint64() % 5
+		rewardLevel += rewardLevelDelta
+		accountChanges := 2
+
+		updates, totals := randomDeltasBalanced(accountChanges, accts[i-1], rewardLevel)
+		prevTotals, err := au.Totals(basics.Round(i - 1))
+		require.NoError(t, err)
+
+		newPool := totals[testPoolAddr]
+		newPool.MicroAlgos.Raw -= prevTotals.RewardUnits() * rewardLevelDelta
+		updates.Upsert(testPoolAddr, newPool)
+		totals[testPoolAddr] = newPool
+
+		blk := bookkeeping.Block{
+			BlockHeader: bookkeeping.BlockHeader{
+				Round: basics.Round(i),
+			},
+		}
+		blk.RewardsLevel = rewardLevel
+		blk.CurrentProtocol = newVersion
+
+		delta := ledgercore.MakeStateDelta(&blk.BlockHeader, 0, updates.Len(), 0)
+		delta.Accts.MergeAccounts(updates)
+		ml.addMockBlock(blockEntry{block: blk}, delta)
+		au.newBlock(blk, delta)
+		accts = append(accts, totals)
+		rewardsLevels = append(rewardsLevels, rewardLevel)
+	}
+	// now, commit and verify that the committedUpTo method broken the range correctly.
+	au.committedUpTo(endOfFirstNewProtocolSegment)
+	au.waitAccountsWriting()
+	require.Equal(t, basics.Round(initialRounds+extraRounds)-1, au.dbRound)
+
+	// write additional extraRounds elements and verify these can be flushed.
+	for i := endOfFirstNewProtocolSegment + 1; i <= basics.Round(initialRounds+2*extraRounds+initialProtoParams.MaxBalLookback); i++ {
+		rewardLevelDelta := crypto.RandUint64() % 5
+		rewardLevel += rewardLevelDelta
+		accountChanges := 2
+
+		updates, totals := randomDeltasBalanced(accountChanges, accts[i-1], rewardLevel)
+		prevTotals, err := au.Totals(basics.Round(i - 1))
+		require.NoError(t, err)
+
+		newPool := totals[testPoolAddr]
+		newPool.MicroAlgos.Raw -= prevTotals.RewardUnits() * rewardLevelDelta
+		updates.Upsert(testPoolAddr, newPool)
+		totals[testPoolAddr] = newPool
+
+		blk := bookkeeping.Block{
+			BlockHeader: bookkeeping.BlockHeader{
+				Round: basics.Round(i),
+			},
+		}
+		blk.RewardsLevel = rewardLevel
+		blk.CurrentProtocol = newVersion
+
+		delta := ledgercore.MakeStateDelta(&blk.BlockHeader, 0, updates.Len(), 0)
+		delta.Accts.MergeAccounts(updates)
+		ml.addMockBlock(blockEntry{block: blk}, delta)
+		au.newBlock(blk, delta)
+		accts = append(accts, totals)
+		rewardsLevels = append(rewardsLevels, rewardLevel)
+	}
+	au.committedUpTo(endOfFirstNewProtocolSegment + basics.Round(extraRounds))
+	au.waitAccountsWriting()
+	require.Equal(t, basics.Round(initialRounds+2*extraRounds), au.dbRound)
+}
+
+// TestConsecutiveVersion tests the consecutiveVersion method correctness.
+func TestConsecutiveVersion(t *testing.T) {
+	var au accountUpdates
+	au.versions = []protocol.ConsensusVersion{
+		protocol.ConsensusV19,
+		protocol.ConsensusV20,
+		protocol.ConsensusV20,
+		protocol.ConsensusV20,
+		protocol.ConsensusV20,
+		protocol.ConsensusV21,
+		protocol.ConsensusV21,
+		protocol.ConsensusV21,
+		protocol.ConsensusV21,
+		protocol.ConsensusV21,
+		protocol.ConsensusV21,
+		protocol.ConsensusV22,
+	}
+	for offset := uint64(1); offset < uint64(len(au.versions)); offset++ {
+		co := au.consecutiveVersion(offset)
+		require.Equal(t, au.versions[1], au.versions[co])
+	}
+	au.versions = []protocol.ConsensusVersion{
+		protocol.ConsensusV19,
+		protocol.ConsensusV20,
+		protocol.ConsensusV21,
+	}
+}
+>>>>>>> 0b885fe3... ledger: fix consensus version flushes incorrectly (#2096)


### PR DESCRIPTION
Make sure mutex is released in commitRound.
provide correct handling for zero-offset changes.

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
