### PR TITLE
Tests: Remove using unreleased semicolon support in AVM test

### DIFF
--- a/ledger/internal/apptxn_test.go
+++ b/ledger/internal/apptxn_test.go
@@ -3310,9 +3310,14 @@ func TestReloadWithTxns(t *testing.T) {
 		dl.fullBlock() // So that the `block` opcode has a block to inspect
 
 		lookHdr := txntest.Txn{
-			Type:            "appl",
-			Sender:          addrs[0],
-			ApprovalProgram: "txn FirstValid;  int 1;  -;  block BlkTimestamp",
+			Type:   "appl",
+			Sender: addrs[0],
+			ApprovalProgram: `
+			  txn FirstValid
+			  int 1
+			  -
+			  block BlkTimestamp
+`,
 		}
 
 		dl.fullBlock(&lookHdr)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

One of the tests pulled included use of semicolons in AVM, which are not yet released.

## Test Plan

N/A; verify CI checks pass in release PR branch.

